### PR TITLE
Add Display-based rendering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,10 +803,22 @@ impl ArrowShape {
 pub type Nodes<'a,N> = Cow<'a,[N]>;
 pub type Edges<'a,E> = Cow<'a,[E]>;
 
+/// Graph kind determines if `digraph` or `graph` is used as keyword
+/// for the graph.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Kind {
+    Digraph,
+    Graph,
+}
+
+// array index is `Kind` discriminant
+const GRAPHKEYWORD: [&'static str; 2] = ["digraph", "graph"];
+const EDGEOP: [&'static str; 2] = ["->", "--"];
+
 // (The type parameters in GraphWalk should be associated items,
 // when/if Rust supports such.)
 
-/// GraphWalk is an abstraction over a directed graph = (nodes,edges)
+/// GraphWalk is an abstraction over a graph = (nodes,edges)
 /// made up of node handles `N` and edge handles `E`, where each `E`
 /// can be mapped to its source and target nodes.
 ///
@@ -828,6 +840,11 @@ pub trait GraphWalk<'a, N: Clone, E: Clone> {
     fn source(&'a self, edge: &E) -> N;
     /// The target node for `edge`.
     fn target(&'a self, edge: &E) -> N;
+    /// The kind of graph, defaults to `Kind::Digraph`.
+    #[inline]
+    fn kind(&self) -> Kind {
+        Kind::Digraph
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -844,7 +861,7 @@ pub fn default_options() -> Vec<RenderOption> {
     vec![]
 }
 
-/// Renders directed graph `g` into the writer `w` in DOT syntax.
+/// Renders graph `g` into the writer `w` in DOT syntax.
 /// (Simple wrapper around `render_opts` that passes a default set of options.)
 pub fn render<'a,
               N: Clone + 'a,
@@ -857,7 +874,7 @@ pub fn render<'a,
     render_opts(g, w, &[])
 }
 
-/// Renders directed graph `g` into the writer `w` in DOT syntax.
+/// Renders graph `g` into the writer `w` in DOT syntax.
 /// (Main entry point for the library.)
 pub fn render_opts<'a,
                    N: Clone + 'a,
@@ -879,7 +896,9 @@ pub fn render_opts<'a,
         w.write_all(b"    ")
     }
 
-    try!(writeln(w, &["digraph ", g.graph_id().as_slice(), " {"]));
+    let kind = g.kind() as usize;
+
+    try!(writeln(w, &[GRAPHKEYWORD[kind], " ", g.graph_id().as_slice(), " {"]));
     for n in g.nodes().iter() {
         try!(indent(w));
         let id = g.node_id(n);
@@ -924,7 +943,7 @@ pub fn render_opts<'a,
         let source_id = g.node_id(&source);
         let target_id = g.node_id(&target);
 
-        let mut text = vec![source_id.as_slice(), " -> ", target_id.as_slice()];
+        let mut text = vec![source_id.as_slice(), " ", EDGEOP[kind], " ", target_id.as_slice()];
 
         if !options.contains(&RenderOption::NoEdgeLabels) {
             text.push("[label=");
@@ -965,7 +984,7 @@ pub fn render_opts<'a,
 #[cfg(test)]
 mod tests {
     use self::NodeLabels::*;
-    use super::{Id, Labeller, Nodes, Edges, GraphWalk, render, Style};
+    use super::{Id, Labeller, Nodes, Edges, GraphWalk, render, Style, Kind};
     use super::LabelText::{self, LabelStr, EscStr, HtmlStr};
     use super::{Arrow, ArrowShape, Side};
     use std::io;
@@ -1024,6 +1043,8 @@ mod tests {
         /// Each edge relates a from-index to a to-index along with a
         /// label; `edges` collects them.
         edges: Vec<Edge>,
+
+        kind: Kind,
     }
 
     // A simple wrapper around LabelledGraph that forces the labels to
@@ -1073,7 +1094,13 @@ mod tests {
                     Some(nodes) => nodes,
                     None => vec![Style::None; count],
                 },
+                kind: Kind::Digraph,
             }
+        }
+
+        fn kind(mut self, kind: Kind) -> Self {
+            self.kind = kind;
+            self
         }
     }
 
@@ -1154,6 +1181,10 @@ mod tests {
         }
         fn target(&'a self, edge: &&'a Edge) -> Node {
             edge.to
+        }
+
+        fn kind(&self) -> Kind {
+            self.kind
         }
     }
 
@@ -1290,17 +1321,17 @@ r#"digraph single_cyclic_node {
                                                    edge(0, 2, "", Style::None),
                                                    edge(1, 3, "", Style::None),
                                                    edge(2, 3, "", Style::None)],
-                                              None));
+                                              None).kind(Kind::Graph));
         assert_eq!(r.unwrap(),
-r#"digraph hasse_diagram {
+r#"graph hasse_diagram {
     N0[label="{x,y}"];
     N1[label="{x}"];
     N2[label="{y}"];
     N3[label="{}"];
-    N0 -> N1[label=""];
-    N0 -> N2[label=""];
-    N1 -> N3[label=""];
-    N2 -> N3[label=""];
+    N0 -- N1[label=""];
+    N0 -- N2[label=""];
+    N1 -- N3[label=""];
+    N2 -- N3[label=""];
 }
 "#);
     }


### PR DESCRIPTION
`Display` based rendering is as versatile as `io::Write` based.

This PR depends on #4, submitted for comments. Only the second commit is relevant.

It's not entirely clear to me if the detour around Display even in the `io::Write` case has any overhead.
