### PR TITLE
Fix Travis CI link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/GrahamDennis/dot-rust.svg?branch=develop)](https://travis-ci.org/GrahamDennis/dot-rust)
+[![Build Status](https://travis-ci.org/przygienda/dot-rust.svg?branch=develop)](https://travis-ci.org/przygienda/dot-rust)
 
 # dot-rust
 


### PR DESCRIPTION
Looks like the repository changed owners at some point and the badge was never updated to reflect this.

Hopefully this unblocks #6.